### PR TITLE
Setup bors-ng

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,14 @@
-on: [push, pull_request]
-
+on:
+  push:
+    branches-ignore:
+      - '*.tmp'
+  pull_request:
+  workflow_dispatch:
 name: CI
+
 env:
   RUST_BACKTRACE: 1
+
 jobs:
   check:
     name: cargo check
@@ -56,3 +62,16 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
+# Job to key the bors success status against
+  bors:
+    name: bors
+    if: success()
+    needs:
+      - check
+      - fmt
+      - test
+      - clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark the job as a success
+        run: exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,12 @@ these guidelines when contributing to the project.
 
 ## How to Contribute
 
-- Bugs: Tracked as ([GitHub issues](https://github.com/collabora/bmap-rs/issues)).
+- Bugs: Tracked as [GitHub issues](https://github.com/collabora/bmap-rs/issues).
 - Enhancements: RFE suggestions are tracked as
-([GitHub issues](https://github.com/collabora/bmap-rs/issues)).
+[GitHub issues](https://github.com/collabora/bmap-rs/issues).
 - Code: Managed on [GitHub](https://github.com/collabora/bmap-rs) through
-  Pull Requests ([PR](https://github.com/collabora/bmap-rs/pulls)).
-- All PRs should pass CI before being merged. 
+  [Pull Requests](https://github.com/collabora/bmap-rs/pulls).
+- All PRs should pass CI before being merged.
+- Maintainers should not press merge on a pull request, instead they should write `bors r+` 
+to a PR. We use [bors](https://github.com/bors-ng/bors-ng) to ensure main branch 
+never breaks.

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,2 @@
+status = [ "bors" ]
+delete_merged_branches = true


### PR DESCRIPTION
Add support for using bors to do pre-merge testing. In particular avoid running CI on branches ending in .tmp as bors uses those for preparation and add a new dummy job to key the bors status against to avoid having to call out all test jobs specifically which would be hard to maintain

Closes: #18

Signed-off-by: Rafael Garcia Ruiz <rafael.garcia@collabora.com>