### PR TITLE
bmap::copy also can truncate file

### DIFF
--- a/bmap-rs/Cargo.toml
+++ b/bmap-rs/Cargo.toml
@@ -10,5 +10,4 @@ edition = "2018"
 bmap = { path = "../bmap" }
 anyhow = "1"
 structopt = "0.3"
-nix = "0.25"
 flate2 = "1"

--- a/bmap-rs/src/main.rs
+++ b/bmap-rs/src/main.rs
@@ -1,11 +1,9 @@
 use anyhow::{anyhow, bail, Context, Result};
 use bmap::{Bmap, Discarder, SeekForward};
 use flate2::read::GzDecoder;
-use nix::unistd::ftruncate;
 use std::ffi::OsStr;
 use std::fs::File;
 use std::io::Read;
-use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 use structopt::StructOpt;
 
@@ -103,8 +101,6 @@ fn copy(c: Copy) -> Result<()> {
         .write(true)
         .create(true)
         .open(c.dest)?;
-
-    ftruncate(output.as_raw_fd(), bmap.image_size() as i64).context("Failed to truncate file")?;
 
     let mut input = setup_input(&c.image)?;
     bmap::copy(&mut input, &mut output, &bmap)?;

--- a/bmap/Cargo.toml
+++ b/bmap/Cargo.toml
@@ -16,3 +16,4 @@ sha2 = { version = "0.10.6", features = [ "asm" ] }
 strum = { version = "0.24.1", features = [ "derive"] }
 digest = "0.10.5"
 flate2 = "1.0.20"
+nix = "0.25"


### PR DESCRIPTION
ftruncate was executed into the main function and it should be done into the copying process if it's needed

Closes: #24 

Signed-off-by: Rafael Garcia Ruiz <rafael.garcia@collabora.com>