### PR TITLE
Solve copying on block device problem

### DIFF
--- a/bmap-rs/src/main.rs
+++ b/bmap-rs/src/main.rs
@@ -104,7 +104,10 @@ fn copy(c: Copy) -> Result<()> {
         .create(true)
         .open(c.dest)?;
 
-    ftruncate(output.as_raw_fd(), bmap.image_size() as i64).context("Failed to truncate file")?;
+    if output.metadata()?.is_file() {
+        ftruncate(output.as_raw_fd(), bmap.image_size() as i64)
+            .context("Failed to truncate file")?;
+    }
 
     let mut input = setup_input(&c.image)?;
     bmap::copy(&mut input, &mut output, &bmap)?;


### PR DESCRIPTION
Before calling bmap::copy the output target was truncated. This is good
if it is a file but when it encounters a block device path it returns:
`EINVAL: Invalid argument`

Now we are checking first if the output target is a regular file, to
avoid that case.

Closes: #11

Signed-off-by: Rafael Garcia Ruiz <rafael.garcia@collabora.com>