### PR TITLE
Download compressed gz image from remote source

### DIFF
--- a/bmap-rs/Cargo.toml
+++ b/bmap-rs/Cargo.toml
@@ -12,5 +12,9 @@ anyhow = "1.0.66"
 nix = "0.26.1"
 flate2 = "1.0.24"
 clap = { version = "4.0.18", features = ["cargo"] }
-indicatif = "0.17.1"
+indicatif = { version = "0.17.1", features = ["tokio"] }
+async-compression = { version = "0.3.15", features = ["gzip", "futures-io"] }
+tokio = { version = "1.21.2", features = ["rt", "macros", "fs", "rt-multi-thread"] }
 reqwest = { version = "0.11.12", features = ["stream"] }
+tokio-util = { version = "0.7.4", features = ["compat"] }
+futures = "0.3.25"

--- a/bmap-rs/Cargo.toml
+++ b/bmap-rs/Cargo.toml
@@ -11,5 +11,6 @@ bmap = { path = "../bmap" }
 anyhow = "1.0.66"
 nix = "0.26.1"
 flate2 = "1.0.24"
-clap = { version = "4.0.18", features = ["derive"] }
+clap = { version = "4.0.18", features = ["cargo"] }
 indicatif = "0.17.1"
+reqwest = { version = "0.11.12", features = ["stream"] }

--- a/bmap/Cargo.toml
+++ b/bmap/Cargo.toml
@@ -15,3 +15,5 @@ sha2 = { version = "0.10.6", features = [ "asm" ] }
 strum = { version = "0.24.1", features = [ "derive"] }
 digest = "0.10.5"
 flate2 = "1.0.20"
+async-trait = "0.1.58"
+futures = "0.3.25"

--- a/bmap/src/lib.rs
+++ b/bmap/src/lib.rs
@@ -2,6 +2,9 @@ mod bmap;
 pub use crate::bmap::*;
 mod discarder;
 pub use crate::discarder::*;
+use async_trait::async_trait;
+use futures::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, AsyncWrite, AsyncWriteExt};
+use futures::TryFutureExt;
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
@@ -16,6 +19,19 @@ pub trait SeekForward {
 impl<T: Seek> SeekForward for T {
     fn seek_forward(&mut self, forward: u64) -> IOResult<()> {
         self.seek(SeekFrom::Current(forward as i64))?;
+        Ok(())
+    }
+}
+
+#[async_trait(?Send)]
+pub trait AsyncSeekForward {
+    async fn async_seek_forward(&mut self, offset: u64) -> IOResult<()>;
+}
+
+#[async_trait(?Send)]
+impl<T: AsyncSeek + Unpin + Send> AsyncSeekForward for T {
+    async fn async_seek_forward(&mut self, forward: u64) -> IOResult<()> {
+        self.seek(SeekFrom::Current(forward as i64)).await?;
         Ok(())
     }
 }
@@ -66,6 +82,60 @@ where
             hasher.update(&buf[0..r]);
             output
                 .write_all(&buf[0..r])
+                .map_err(CopyError::WriteError)?;
+            left -= r;
+        }
+        let digest = hasher.finalize_reset();
+        if range.checksum().as_slice() != digest.as_slice() {
+            return Err(CopyError::ChecksumError);
+        }
+
+        position = range.offset() + range.length();
+    }
+
+    Ok(())
+}
+
+pub async fn copy_async<I, O>(input: &mut I, output: &mut O, map: &Bmap) -> Result<(), CopyError>
+where
+    I: AsyncRead + AsyncSeekForward + Unpin,
+    O: AsyncWrite + AsyncSeekForward + Unpin,
+{
+    let mut hasher = match map.checksum_type() {
+        HashType::Sha256 => Sha256::new(),
+    };
+    let mut v = Vec::new();
+    // TODO benchmark a reasonable size for this
+    v.resize(8 * 1024 * 1024, 0);
+
+    let buf = v.as_mut_slice();
+    let mut position = 0;
+    for range in map.block_map() {
+        let forward = range.offset() - position;
+        input
+            .async_seek_forward(forward)
+            .map_err(CopyError::ReadError)
+            .await?;
+        output.flush().map_err(CopyError::WriteError).await?;
+        output
+            .async_seek_forward(forward)
+            .map_err(CopyError::WriteError)
+            .await?;
+
+        let mut left = range.length() as usize;
+        while left > 0 {
+            let toread = left.min(buf.len());
+            let r = input
+                .read(&mut buf[0..toread])
+                .map_err(CopyError::ReadError)
+                .await?;
+            if r == 0 {
+                return Err(CopyError::UnexpectedEof);
+            }
+            hasher.update(&buf[0..r]);
+            output
+                .write_all(&buf[0..r])
+                .await
                 .map_err(CopyError::WriteError)?;
             left -= r;
         }


### PR DESCRIPTION
Accept url arguments for remote image download and copy.
Implements async support for use of reqwest. Bmap file is searched as in
local option in the current file with same name and the extension ".bmap"
Closes: #9 
Closes: #46 
Closes: #8 

Signed-off-by: Rafael Garcia Ruiz <rafael.garcia@collabora.com>