### PR TITLE
Replace structopt library with clap

### DIFF
--- a/bmap-rs/Cargo.toml
+++ b/bmap-rs/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2018"
 [dependencies]
 bmap = { path = "../bmap" }
 anyhow = "1"
-structopt = "0.3"
 nix = "0.25"
 flate2 = "1"
+clap = { version = "4.0.18", features = ["derive"] }

--- a/bmap-rs/src/main.rs
+++ b/bmap-rs/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, bail, Context, Result};
 use bmap::{Bmap, Discarder, SeekForward};
+use clap::Parser;
 use flate2::read::GzDecoder;
 use nix::unistd::ftruncate;
 use std::ffi::OsStr;
@@ -7,22 +8,22 @@ use std::fs::File;
 use std::io::Read;
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
-use structopt::StructOpt;
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 struct Copy {
     image: PathBuf,
     dest: PathBuf,
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
+
 enum Command {
     Copy(Copy),
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Parser, Debug)]
 struct Opts {
-    #[structopt(subcommand)]
+    #[command(subcommand)]
     command: Command,
 }
 
@@ -118,7 +119,7 @@ fn copy(c: Copy) -> Result<()> {
 }
 
 fn main() -> Result<()> {
-    let opts = Opts::from_args();
+    let opts = Opts::parse();
 
     match opts.command {
         Command::Copy(c) => copy(c),

--- a/bmap/Cargo.toml
+++ b/bmap/Cargo.toml
@@ -11,7 +11,6 @@ thiserror = "1.0.24"
 quick-xml = { version = "0.26.0", features = [ "serialize" ] }
 serde = { version = "1", features = [ "derive" ] }
 anyhow = { version = "1.0.40", optional = true }
-structopt = { version = "0.3.21", optional = true }
 sha2 = { version = "0.10.6", features = [ "asm" ] }
 strum = { version = "0.24.1", features = [ "derive"] }
 digest = "0.10.5"


### PR DESCRIPTION
Since all features of structopt are into clap now and it won't have futures updates we have replaced it.
Closes: #35 

Signed-off-by: Rafael Garcia Ruiz <rafael.garcia@collabora.com>