### PR TITLE
Support copying an image without a bmap file

### DIFF
--- a/bmap-parser/src/lib.rs
+++ b/bmap-parser/src/lib.rs
@@ -146,6 +146,25 @@ where
 
         position = range.offset() + range.length();
     }
+    Ok(())
+}
 
+pub fn copy_nobmap<I, O>(input: &mut I, output: &mut O) -> Result<(), CopyError>
+where
+    I: Read,
+    O: Write,
+{
+    std::io::copy(input, output).map_err(CopyError::WriteError)?;
+    Ok(())
+}
+
+pub async fn copy_async_nobmap<I, O>(input: &mut I, output: &mut O) -> Result<(), CopyError>
+where
+    I: AsyncRead + AsyncSeekForward + Unpin,
+    O: AsyncWrite + AsyncSeekForward + Unpin,
+{
+    futures::io::copy(input, output)
+        .map_err(CopyError::WriteError)
+        .await?;
     Ok(())
 }


### PR DESCRIPTION
--nobmap or -n flag allows copying without a bmap file.
Closes: #39

Signed-off-by: Rafael Garcia Ruiz <rafael.garcia@collabora.com>