### PR TITLE
Custom parser function

### DIFF
--- a/bmap-rs/Cargo.toml
+++ b/bmap-rs/Cargo.toml
@@ -13,3 +13,4 @@ nix = "0.25.0"
 flate2 = "1.0.24"
 clap = { version = "4.0.18", features = ["cargo"] }
 indicatif = "0.17.1"
+reqwest = { version = "0.11.12" }

--- a/bmap-rs/Cargo.toml
+++ b/bmap-rs/Cargo.toml
@@ -11,5 +11,5 @@ bmap = { path = "../bmap" }
 anyhow = "1.0.66"
 nix = "0.25.0"
 flate2 = "1.0.24"
-clap = { version = "4.0.18", features = ["derive"] }
+clap = { version = "4.0.18", features = ["cargo"] }
 indicatif = "0.17.1"

--- a/bmap-rs/src/main.rs
+++ b/bmap-rs/src/main.rs
@@ -18,6 +18,7 @@ enum Image {
     Url(Url),
 }
 
+#[allow(dead_code)] // To be erased when remote input implemented
 impl Image {
     fn path(self) -> Result<PathBuf> {
         if let Image::Path(c) = self {
@@ -27,10 +28,13 @@ impl Image {
         }
     }
 
-    // Commented to avoid unused code warning
-    //fn url(self) -> Result<Url> {
-    //    if let Image::Url(d) = self { Ok(d) } else { bail!("Not a url") }
-    //}
+    fn url(self) -> Result<Url> {
+        if let Image::Url(d) = self {
+            Ok(d)
+        } else {
+            bail!("Not a url")
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/bmap-rs/src/main.rs
+++ b/bmap-rs/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, bail, Context, Result};
 use bmap::{Bmap, Discarder, SeekForward};
-use clap::{arg, command, ArgMatches, Command as Command_clap};
+use clap::{arg, command, ArgMatches, Command};
 use flate2::read::GzDecoder;
 use indicatif::{ProgressBar, ProgressState, ProgressStyle};
 use nix::unistd::ftruncate;
@@ -51,13 +51,13 @@ impl Copy {
 
 #[derive(Debug)]
 
-enum Command {
+enum Subcommand {
     Copy(Copy),
 }
 
 #[derive(Debug)]
 struct Opts {
-    command: Command,
+    command: Subcommand,
 }
 
 fn parser() -> Opts {
@@ -66,7 +66,7 @@ fn parser() -> Opts {
         .subcommand_required(true)
         .arg_required_else_help(true)
         .subcommand(
-            Command_clap::new("copy")
+            Command::new("copy")
                 .about("Copy disk image to destiny")
                 .arg(arg!([IMAGE]).required(true))
                 .arg(arg!([DESTINY]).required(true)),
@@ -74,7 +74,7 @@ fn parser() -> Opts {
         .get_matches();
     match matches.subcommand() {
         Some(("copy", sub_matches)) => Opts {
-            command: Command::Copy(Copy::parse(sub_matches)),
+            command: Subcommand::Copy(Copy::parse(sub_matches)),
         },
         _ => unreachable!("Exhausted list of subcommands and subcommand_required prevents `None`"),
     }
@@ -183,6 +183,6 @@ fn main() -> Result<()> {
     let opts = parser();
 
     match opts.command {
-        Command::Copy(c) => copy(c),
+        Subcommand::Copy(c) => copy(c),
     }
 }

--- a/bmap-rs/src/main.rs
+++ b/bmap-rs/src/main.rs
@@ -19,17 +19,17 @@ enum Image {
 }
 
 impl Image {
-    fn path(self) -> PathBuf {
+    fn path(self) -> Result<PathBuf> {
         if let Image::Path(c) = self {
-            c
+            Ok(c)
         } else {
-            panic!("Not a path")
+            bail!("Not a path")
         }
     }
 
     // Commented to avoid unused code warning
-    //fn url(self) -> Url {
-    //    if let Image::Url(d) = self { d } else { panic!("Not a url") }
+    //fn url(self) -> Result<Url> {
+    //    if let Image::Url(d) = self { Ok(d) } else { bail!("Not a url") }
     //}
 }
 
@@ -141,7 +141,7 @@ fn setup_input(path: &Path) -> Result<Decoder> {
 }
 
 fn copy(c: Copy) -> Result<()> {
-    let image = c.image.path();
+    let image = c.image.path()?;
     if !image.exists() {
         bail!("Image file doesn't exist")
     }


### PR DESCRIPTION
To handle the possibility of the image route been a path or a url the new parser uses an enum Image to keep that information and avoid repeated type parsing.
Closes: #46 

Signed-off-by: Rafael Garcia Ruiz <rafael.garcia@collabora.com>