### PR TITLE
Bmap file integrity check

### DIFF
--- a/bmap-parser/src/bmap.rs
+++ b/bmap-parser/src/bmap.rs
@@ -57,6 +57,7 @@ pub struct Bmap {
     blocks: u64,
     mapped_blocks: u64,
     checksum_type: HashType,
+    bmap_file_checksum: String,
     blockmap: Vec<BlockRange>,
 }
 
@@ -92,6 +93,11 @@ impl Bmap {
     pub fn block_map(&self) -> impl ExactSizeIterator + Iterator<Item = &BlockRange> {
         self.blockmap.iter()
     }
+
+    pub fn bmap_file_checksum(&self) -> String {
+        self.bmap_file_checksum.clone()
+    }
+
     pub fn total_mapped_size(&self) -> u64 {
         self.block_size * self.mapped_blocks
     }
@@ -109,6 +115,8 @@ pub enum BmapBuilderError {
     MissingMappedBlocks,
     #[error("Checksum type missing")]
     MissingChecksumType,
+    #[error("Bmap file checksum missing")]
+    MissingBmapFileChecksum,
     #[error("No block ranges")]
     NoBlockRanges,
 }
@@ -120,6 +128,7 @@ pub struct BmapBuilder {
     blocks: Option<u64>,
     checksum_type: Option<HashType>,
     mapped_blocks: Option<u64>,
+    bmap_file_checksum: Option<String>,
     blockmap: Vec<BlockRange>,
 }
 
@@ -146,6 +155,11 @@ impl BmapBuilder {
 
     pub fn checksum_type(&mut self, checksum_type: HashType) -> &mut Self {
         self.checksum_type = Some(checksum_type);
+        self
+    }
+
+    pub fn bmap_file_checksum(&mut self, bmap_file_checksum: String) -> &mut Self {
+        self.bmap_file_checksum = Some(bmap_file_checksum);
         self
     }
 
@@ -177,6 +191,9 @@ impl BmapBuilder {
         let checksum_type = self
             .checksum_type
             .ok_or(BmapBuilderError::MissingChecksumType)?;
+        let bmap_file_checksum = self
+            .bmap_file_checksum
+            .ok_or(BmapBuilderError::MissingBmapFileChecksum)?;
         let blockmap = self.blockmap;
 
         Ok(Bmap {
@@ -185,6 +202,7 @@ impl BmapBuilder {
             blocks,
             mapped_blocks,
             checksum_type,
+            bmap_file_checksum,
             blockmap,
         })
     }

--- a/bmap-parser/src/bmap/xml.rs
+++ b/bmap-parser/src/bmap/xml.rs
@@ -96,6 +96,7 @@ pub(crate) fn from_xml(xml: &str) -> Result<crate::bmap::Bmap, XmlError> {
         .block_size(b.block_size)
         .blocks(b.blocks_count)
         .checksum_type(hash_type)
+        .bmap_file_checksum(b.bmap_file_checksum)
         .mapped_blocks(b.mapped_blocks_count);
 
     for range in b.block_map.ranges {

--- a/bmap-rs/Cargo.toml
+++ b/bmap-rs/Cargo.toml
@@ -22,3 +22,5 @@ tokio = { version = "1.21.2", features = ["rt", "macros", "fs", "rt-multi-thread
 reqwest = { version = "0.11.12", features = ["stream"] }
 tokio-util = { version = "0.7.4", features = ["compat"] }
 futures = "0.3.25"
+sha2 = { version = "0.10.6", features = [ "asm" ] }
+hex = "0.4.3"

--- a/bmap-rs/src/main.rs
+++ b/bmap-rs/src/main.rs
@@ -249,6 +249,7 @@ async fn copy_remote_input(source: Url, destination: PathBuf) -> Result<()> {
     println!("Found bmap file: {}", bmap_url);
 
     let bmap = Bmap::from_xml(&xml)?;
+    bmap_integrity(bmap.bmap_file_checksum(), xml)?;
     let mut output = tokio::fs::OpenOptions::new()
         .write(true)
         .create(true)


### PR DESCRIPTION
Checks if the bmap hash is correct for the current bmap file.
Bmap file checksum is calculated having that field as all 0s.

Closes: #50

Signed-off-by: Rafael Garcia Ruiz <rafael.garcia@collabora.com>