### PR TITLE
Fix clippy error: slow zero-filling initialization

### DIFF
--- a/bmap-parser/src/lib.rs
+++ b/bmap-parser/src/lib.rs
@@ -57,9 +57,8 @@ where
         HashType::Sha256 => Sha256::new(),
     };
 
-    let mut v = Vec::new();
     // TODO benchmark a reasonable size for this
-    v.resize(8 * 1024 * 1024, 0);
+    let mut v = vec![0; 8 * 1024 * 1024];
 
     let buf = v.as_mut_slice();
     let mut position = 0;
@@ -104,9 +103,9 @@ where
     let mut hasher = match map.checksum_type() {
         HashType::Sha256 => Sha256::new(),
     };
-    let mut v = Vec::new();
+
     // TODO benchmark a reasonable size for this
-    v.resize(8 * 1024 * 1024, 0);
+    let mut v = vec![0; 8 * 1024 * 1024];
 
     let buf = v.as_mut_slice();
     let mut position = 0;


### PR DESCRIPTION
Clippy produces an error:

    error: slow zero-filling initialization
    Error:   --> bmap-parser/src/lib.rs:62:5
       |
    60 |     let mut v = Vec::new();
       |                 ---------- help: consider replacing this with: `vec![0; 8 * 1024 * 1024]`
    61 |     // TODO benchmark a reasonable size for this
    62 |     v.resize(8 * 1024 * 1024, 0);
       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    error: slow zero-filling initialization
    Error:    --> bmap-parser/src/lib.rs:109:5
        |
    107 |     let mut v = Vec::new();
        |                 ---------- help: consider replacing this with: `vec![0; 8 * 1024 * 1024]`
    108 |     // TODO benchmark a reasonable size for this
    109 |     v.resize(8 * 1024 * 1024, 0);
        |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

Fix it by following the suggestions.