### PR TITLE
ci: Add allgreen job to signify overall workflow status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,10 +62,11 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
-# Job to key the bors success status against
-  bors:
-    name: bors
-    if: success()
+
+  # Job to key success status against
+  allgreen:
+    name: allgreen
+    if: always()
     needs:
       - check
       - fmt
@@ -73,5 +74,7 @@ jobs:
       - clippy
     runs-on: ubuntu-latest
     steps:
-      - name: Mark the job as a success
-        run: exit 0
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
Rework the bors job (which signifies overall workflow status) into a more generic job named allgreen.