### PR TITLE
Strip release binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,8 @@ resolver = "3"
 [profile.dev]
 opt-level = 3
 
+[profile.release]
+strip = true
+
 [workspace.package]
 rust-version = "1.85"


### PR DESCRIPTION
Strip release builds to get smaller binaries.
The change reduces current binary size from 4.8MiB to 3.8MiB.