### PR TITLE
chore: Bump sha2/digest versions

### DIFF
--- a/bmap-parser/Cargo.toml
+++ b/bmap-parser/Cargo.toml
@@ -16,9 +16,9 @@ thiserror = "2.0.17"
 quick-xml = { version = "0.39.2", features = [ "serialize" ] }
 serde = { version = "1.0.147", features = [ "derive" ] }
 anyhow = { version = "1.0.40", optional = true }
-sha2 = { version = "0.10.6", features = [ "asm" ] }
+sha2 = { version = "0.11" }
 strum = { version = "0.28.0", features = [ "derive"] }
-digest = "0.10.5"
+digest = "0.11"
 flate2 = "1.0.20"
 async-trait = "0.1.58"
 futures = "0.3.25"


### PR DESCRIPTION
For sha2 the asm feature has been removed, with system features seemingly detected at runtime.