### PR TITLE
Add support for bzip2, xz, zstd, lzma and zlib and their .tar conterparts

### DIFF
--- a/bmap-rs/Cargo.toml
+++ b/bmap-rs/Cargo.toml
@@ -27,3 +27,4 @@ bzip2 = "0.6.1"
 zstd = "0.13.3"
 liblzma = "0.4.7"
 lz4_flex = "0.14.0"
+tar = { version = "0.4.46", default-features = false }

--- a/bmap-rs/Cargo.toml
+++ b/bmap-rs/Cargo.toml
@@ -18,8 +18,12 @@ nix = { version = "0.31.1", features = ["fs"] }
 flate2 = "1.0.24"
 clap = { version = "~4.4.0", features = ["cargo"] }
 indicatif = { version = "0.18.2", features = ["tokio"] }
-async-compression = { version = "0.4.5", features = ["gzip", "futures-io"] }
+async-compression = { version = "0.4.5", features = ["gzip", "bzip2", "xz", "zstd", "lzma", "lz4", "zlib", "futures-io"] }
 tokio = { version = "1.21.2", features = ["rt", "macros", "fs", "rt-multi-thread"] }
 reqwest = { version = "0.13.2", features = ["stream"] }
 tokio-util = { version = "0.7.4", features = ["compat"] }
 futures = "0.3.25"
+bzip2 = "0.6.1"
+zstd = "0.13.3"
+liblzma = "0.4.7"
+lz4_flex = "0.14.0"

--- a/bmap-rs/src/main.rs
+++ b/bmap-rs/src/main.rs
@@ -4,6 +4,7 @@ use bmap_parser::{AsyncDiscarder, Bmap, Discarder, SeekForward};
 use clap::{Arg, ArgAction, Command, arg, command};
 use flate2::read::GzDecoder;
 use futures::TryStreamExt;
+use futures::io::AsyncRead;
 use indicatif::{ProgressBar, ProgressState, ProgressStyle};
 use nix::unistd::ftruncate;
 use reqwest::{Response, Url};
@@ -147,6 +148,17 @@ fn setup_local_input(path: &Path) -> Result<Decoder> {
     }
 }
 
+fn wrap_async_decoder<S>(path: &Path, stream: S) -> Result<Box<dyn AsyncRead + Unpin + Send>>
+where
+    S: futures::io::AsyncBufRead + Unpin + Send + 'static,
+{
+    match path.extension().and_then(OsStr::to_str) {
+        Some("gz") => Ok(Box::new(GzipDecoder::new(stream))),
+        None => bail!("No file extension found"),
+        _ => bail!("Image file format not implemented"),
+    }
+}
+
 async fn setup_remote_input(url: Url) -> Result<Response> {
     match PathBuf::from(url.path())
         .extension()
@@ -238,12 +250,13 @@ async fn copy_remote_input(source: Url, destination: PathBuf) -> Result<()> {
 
     setup_output(&output, &bmap, output.metadata().await?)?;
 
+    let path = PathBuf::from(source.path());
     let res = setup_remote_input(source).await?;
     let stream = res
         .bytes_stream()
         .map_err(std::io::Error::other)
         .into_async_read();
-    let reader = GzipDecoder::new(stream);
+    let reader = wrap_async_decoder(&path, stream)?;
     let mut input = AsyncDiscarder::new(reader);
     let pb = setup_progress_bar(&bmap);
     bmap_parser::copy_async(
@@ -288,12 +301,13 @@ async fn copy_remote_input_nobmap(source: Url, destination: PathBuf) -> Result<(
         .open(destination)
         .await?;
 
+    let path = PathBuf::from(source.path());
     let res = setup_remote_input(source).await?;
     let stream = res
         .bytes_stream()
         .map_err(std::io::Error::other)
         .into_async_read();
-    let reader = GzipDecoder::new(stream);
+    let reader = wrap_async_decoder(&path, stream)?;
     let mut input = AsyncDiscarder::new(reader);
     let pb = setup_spinner();
     bmap_parser::copy_async_nobmap(&mut input, &mut pb.wrap_async_write(&mut output).compat())

--- a/bmap-rs/src/main.rs
+++ b/bmap-rs/src/main.rs
@@ -1,11 +1,17 @@
 use anyhow::{Context, Result, anyhow, bail, ensure};
-use async_compression::futures::bufread::GzipDecoder;
+use async_compression::futures::bufread::{
+    BzDecoder, GzipDecoder, Lz4Decoder, LzmaDecoder, XzDecoder, ZlibDecoder, ZstdDecoder,
+};
 use bmap_parser::{AsyncDiscarder, Bmap, Discarder, SeekForward};
+use bzip2::read::BzDecoder as BzSyncDecoder;
 use clap::{Arg, ArgAction, Command, arg, command};
-use flate2::read::GzDecoder;
+use flate2::read::{GzDecoder, ZlibDecoder as ZlibSyncDecoder};
 use futures::TryStreamExt;
 use futures::io::AsyncRead;
 use indicatif::{ProgressBar, ProgressState, ProgressStyle};
+use liblzma::read::XzDecoder as XzSyncDecoder;
+use liblzma::stream::Stream as LzmaStream;
+use lz4_flex::frame::FrameDecoder as Lz4SyncDecoder;
 use nix::unistd::ftruncate;
 use reqwest::{Response, Url};
 use std::ffi::OsStr;
@@ -15,6 +21,39 @@ use std::io::Read;
 use std::os::unix::io::AsFd;
 use std::path::{Path, PathBuf};
 use tokio_util::compat::TokioAsyncReadCompatExt;
+use zstd::stream::read::Decoder as ZstdSyncDecoder;
+
+/// Compression algorithm applied to an image.
+#[derive(Debug, Clone, Copy)]
+enum Compression {
+    Gzip,
+    Bzip2,
+    Xz,
+    Zstd,
+    Lzma,
+    Lz4,
+    Zlib,
+}
+
+/// Determine the compression algorithm used for an image from its file name.
+/// Returns `None` if the file name doesn't have a recognized extension.
+fn classify_format(path: &Path) -> Option<Compression> {
+    let name = path.file_name().and_then(OsStr::to_str)?;
+    let lower = name.to_lowercase();
+    const FORMATS: &[(&str, Compression)] = &[
+        (".gz", Compression::Gzip),
+        (".bz2", Compression::Bzip2),
+        (".xz", Compression::Xz),
+        (".zst", Compression::Zstd),
+        (".lzma", Compression::Lzma),
+        (".lz4", Compression::Lz4),
+        (".zz", Compression::Zlib),
+    ];
+    FORMATS
+        .iter()
+        .find(|(suffix, _)| lower.ends_with(suffix))
+        .map(|(_, compression)| *compression)
+}
 
 #[derive(Debug)]
 enum Image {
@@ -139,12 +178,20 @@ impl SeekForward for Decoder {
 
 fn setup_local_input(path: &Path) -> Result<Decoder> {
     let f = File::open(path)?;
-    match path.extension().and_then(OsStr::to_str) {
-        Some("gz") => {
-            let gz = GzDecoder::new(f);
-            Ok(Decoder::new(Discarder::new(gz)))
+    match classify_format(path) {
+        Some(Compression::Gzip) => Ok(Decoder::new(Discarder::new(GzDecoder::new(f)))),
+        Some(Compression::Bzip2) => Ok(Decoder::new(Discarder::new(BzSyncDecoder::new(f)))),
+        Some(Compression::Xz) => Ok(Decoder::new(Discarder::new(XzSyncDecoder::new(f)))),
+        Some(Compression::Zstd) => Ok(Decoder::new(Discarder::new(ZstdSyncDecoder::new(f)?))),
+        Some(Compression::Lzma) => {
+            let stream = LzmaStream::new_lzma_decoder(u64::MAX)?;
+            Ok(Decoder::new(Discarder::new(XzSyncDecoder::new_stream(
+                f, stream,
+            ))))
         }
-        _ => Ok(Decoder::new(f)),
+        Some(Compression::Lz4) => Ok(Decoder::new(Discarder::new(Lz4SyncDecoder::new(f)))),
+        Some(Compression::Zlib) => Ok(Decoder::new(Discarder::new(ZlibSyncDecoder::new(f)))),
+        None => Ok(Decoder::new(f)),
     }
 }
 
@@ -152,21 +199,32 @@ fn wrap_async_decoder<S>(path: &Path, stream: S) -> Result<Box<dyn AsyncRead + U
 where
     S: futures::io::AsyncBufRead + Unpin + Send + 'static,
 {
-    match path.extension().and_then(OsStr::to_str) {
-        Some("gz") => Ok(Box::new(GzipDecoder::new(stream))),
-        None => bail!("No file extension found"),
-        _ => bail!("Image file format not implemented"),
+    match classify_format(path) {
+        Some(Compression::Gzip) => Ok(Box::new(GzipDecoder::new(stream))),
+        Some(Compression::Bzip2) => Ok(Box::new(BzDecoder::new(stream))),
+        Some(Compression::Xz) => Ok(Box::new(XzDecoder::new(stream))),
+        Some(Compression::Zstd) => {
+            let mut zstd = ZstdDecoder::new(stream);
+            // async_compression's ZstdDecoder defaults to decoding only the
+            // first frame, unlike zstd::stream::read::Decoder (used on the
+            // sync path) which decodes all concatenated frames. Without this,
+            // a multi-frame image (e.g. produced by pzstd) would be silently
+            // truncated after the first frame.
+            zstd.multiple_members(true);
+            Ok(Box::new(zstd))
+        }
+        Some(Compression::Lzma) => Ok(Box::new(LzmaDecoder::new(stream))),
+        Some(Compression::Lz4) => Ok(Box::new(Lz4Decoder::new(stream))),
+        Some(Compression::Zlib) => Ok(Box::new(ZlibDecoder::new(stream))),
+        None => bail!("Image file format not implemented"),
     }
 }
 
 async fn setup_remote_input(url: Url) -> Result<Response> {
-    match PathBuf::from(url.path())
-        .extension()
-        .and_then(OsStr::to_str)
-    {
-        Some("gz") => reqwest::get(url).await.map_err(anyhow::Error::new),
-        None => bail!("No file extension found"),
-        _ => bail!("Image file format not implemented"),
+    let path = PathBuf::from(url.path());
+    match classify_format(&path) {
+        Some(_) => reqwest::get(url).await.map_err(anyhow::Error::new),
+        None => bail!("Image file format not implemented"),
     }
 }
 

--- a/bmap-rs/src/main.rs
+++ b/bmap-rs/src/main.rs
@@ -178,32 +178,36 @@ impl SeekForward for Decoder {
 
 fn setup_local_input(path: &Path) -> Result<Decoder> {
     let f = File::open(path)?;
-    match classify_format(path) {
-        Some(Compression::Gzip) => Ok(Decoder::new(Discarder::new(GzDecoder::new(f)))),
-        Some(Compression::Bzip2) => Ok(Decoder::new(Discarder::new(BzSyncDecoder::new(f)))),
-        Some(Compression::Xz) => Ok(Decoder::new(Discarder::new(XzSyncDecoder::new(f)))),
-        Some(Compression::Zstd) => Ok(Decoder::new(Discarder::new(ZstdSyncDecoder::new(f)?))),
-        Some(Compression::Lzma) => {
+    let compression = match classify_format(path) {
+        Some(compression) => compression,
+        None => return Ok(Decoder::new(f)),
+    };
+    let decompressed: Box<dyn Read> = match compression {
+        Compression::Gzip => Box::new(GzDecoder::new(f)),
+        Compression::Bzip2 => Box::new(BzSyncDecoder::new(f)),
+        Compression::Xz => Box::new(XzSyncDecoder::new(f)),
+        Compression::Zstd => Box::new(ZstdSyncDecoder::new(f)?),
+        Compression::Lzma => {
             let stream = LzmaStream::new_lzma_decoder(u64::MAX)?;
-            Ok(Decoder::new(Discarder::new(XzSyncDecoder::new_stream(
-                f, stream,
-            ))))
+            Box::new(XzSyncDecoder::new_stream(f, stream))
         }
-        Some(Compression::Lz4) => Ok(Decoder::new(Discarder::new(Lz4SyncDecoder::new(f)))),
-        Some(Compression::Zlib) => Ok(Decoder::new(Discarder::new(ZlibSyncDecoder::new(f)))),
-        None => Ok(Decoder::new(f)),
-    }
+        Compression::Lz4 => Box::new(Lz4SyncDecoder::new(f)),
+        Compression::Zlib => Box::new(ZlibSyncDecoder::new(f)),
+    };
+    Ok(Decoder::new(Discarder::new(decompressed)))
 }
 
 fn wrap_async_decoder<S>(path: &Path, stream: S) -> Result<Box<dyn AsyncRead + Unpin + Send>>
 where
     S: futures::io::AsyncBufRead + Unpin + Send + 'static,
 {
-    match classify_format(path) {
-        Some(Compression::Gzip) => Ok(Box::new(GzipDecoder::new(stream))),
-        Some(Compression::Bzip2) => Ok(Box::new(BzDecoder::new(stream))),
-        Some(Compression::Xz) => Ok(Box::new(XzDecoder::new(stream))),
-        Some(Compression::Zstd) => {
+    let compression =
+        classify_format(path).ok_or_else(|| anyhow!("Image file format not implemented"))?;
+    let decompressed: Box<dyn AsyncRead + Unpin + Send> = match compression {
+        Compression::Gzip => Box::new(GzipDecoder::new(stream)),
+        Compression::Bzip2 => Box::new(BzDecoder::new(stream)),
+        Compression::Xz => Box::new(XzDecoder::new(stream)),
+        Compression::Zstd => {
             let mut zstd = ZstdDecoder::new(stream);
             // async_compression's ZstdDecoder defaults to decoding only the
             // first frame, unlike zstd::stream::read::Decoder (used on the
@@ -211,13 +215,13 @@ where
             // a multi-frame image (e.g. produced by pzstd) would be silently
             // truncated after the first frame.
             zstd.multiple_members(true);
-            Ok(Box::new(zstd))
+            Box::new(zstd)
         }
-        Some(Compression::Lzma) => Ok(Box::new(LzmaDecoder::new(stream))),
-        Some(Compression::Lz4) => Ok(Box::new(Lz4Decoder::new(stream))),
-        Some(Compression::Zlib) => Ok(Box::new(ZlibDecoder::new(stream))),
-        None => bail!("Image file format not implemented"),
-    }
+        Compression::Lzma => Box::new(LzmaDecoder::new(stream)),
+        Compression::Lz4 => Box::new(Lz4Decoder::new(stream)),
+        Compression::Zlib => Box::new(ZlibDecoder::new(stream)),
+    };
+    Ok(decompressed)
 }
 
 async fn setup_remote_input(url: Url) -> Result<Response> {

--- a/bmap-rs/src/main.rs
+++ b/bmap-rs/src/main.rs
@@ -7,7 +7,7 @@ use bzip2::read::BzDecoder as BzSyncDecoder;
 use clap::{Arg, ArgAction, Command, arg, command};
 use flate2::read::{GzDecoder, ZlibDecoder as ZlibSyncDecoder};
 use futures::TryStreamExt;
-use futures::io::AsyncRead;
+use futures::io::{AsyncRead, AsyncReadExt};
 use indicatif::{ProgressBar, ProgressState, ProgressStyle};
 use liblzma::read::XzDecoder as XzSyncDecoder;
 use liblzma::stream::Stream as LzmaStream;
@@ -17,15 +17,25 @@ use reqwest::{Response, Url};
 use std::ffi::OsStr;
 use std::fmt::Write;
 use std::fs::File;
-use std::io::Read;
+use std::io::{self, Read};
 use std::os::unix::io::AsFd;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::task::{Context as TaskContext, Poll};
+use tar::Header as TarHeader;
 use tokio_util::compat::TokioAsyncReadCompatExt;
 use zstd::stream::read::Decoder as ZstdSyncDecoder;
 
-/// Compression algorithm applied to an image.
-#[derive(Debug, Clone, Copy)]
+const TAR_BLOCK_SIZE: u64 = 512;
+
+fn tar_padded_size(size: u64) -> u64 {
+    size.div_ceil(TAR_BLOCK_SIZE) * TAR_BLOCK_SIZE
+}
+
+/// Compression algorithm applied to an image, if any.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Compression {
+    None,
     Gzip,
     Bzip2,
     Xz,
@@ -35,24 +45,168 @@ enum Compression {
     Zlib,
 }
 
-/// Determine the compression algorithm used for an image from its file name.
+/// The on-disk format of an image, as derived from its file name: the
+/// compression algorithm used (if any) and whether the (decompressed)
+/// content is wrapped in a tar archive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Format {
+    compression: Compression,
+    tar: bool,
+}
+
+/// Determine the compression/archive format of an image from its file name.
 /// Returns `None` if the file name doesn't have a recognized extension.
-fn classify_format(path: &Path) -> Option<Compression> {
+fn classify_format(path: &Path) -> Option<Format> {
     let name = path.file_name().and_then(OsStr::to_str)?;
     let lower = name.to_lowercase();
-    const FORMATS: &[(&str, Compression)] = &[
-        (".gz", Compression::Gzip),
-        (".bz2", Compression::Bzip2),
-        (".xz", Compression::Xz),
-        (".zst", Compression::Zstd),
-        (".lzma", Compression::Lzma),
-        (".lz4", Compression::Lz4),
-        (".zz", Compression::Zlib),
+    const FORMATS: &[(&str, Compression, bool)] = &[
+        (".tar.gz", Compression::Gzip, true),
+        (".tgz", Compression::Gzip, true),
+        (".tar.bz2", Compression::Bzip2, true),
+        (".tbz2", Compression::Bzip2, true),
+        (".tbz", Compression::Bzip2, true),
+        (".tb2", Compression::Bzip2, true),
+        (".tar.xz", Compression::Xz, true),
+        (".txz", Compression::Xz, true),
+        (".tar.zst", Compression::Zstd, true),
+        (".tzst", Compression::Zstd, true),
+        (".tar.lz4", Compression::Lz4, true),
+        (".tar.lzma", Compression::Lzma, true),
+        (".tar.zz", Compression::Zlib, true),
+        (".tar", Compression::None, true),
+        (".gz", Compression::Gzip, false),
+        (".bz2", Compression::Bzip2, false),
+        (".xz", Compression::Xz, false),
+        (".zst", Compression::Zstd, false),
+        (".lzma", Compression::Lzma, false),
+        (".lz4", Compression::Lz4, false),
+        (".zz", Compression::Zlib, false),
     ];
     FORMATS
         .iter()
-        .find(|(suffix, _)| lower.ends_with(suffix))
-        .map(|(_, compression)| *compression)
+        .find(|(suffix, ..)| lower.ends_with(suffix))
+        .map(|(_, compression, tar)| Format {
+            compression: *compression,
+            tar: *tar,
+        })
+}
+
+/// A reader that extracts the first regular file found in a tar stream,
+/// skipping over any other entries (directories, GNU long name/pax headers,
+/// ...) it may encounter first.
+struct TarFileReader<R> {
+    inner: R,
+    remaining: u64,
+}
+
+impl<R: Read> TarFileReader<R> {
+    fn new(mut inner: R) -> Result<Self> {
+        loop {
+            let mut block = [0u8; TAR_BLOCK_SIZE as usize];
+            inner
+                .read_exact(&mut block)
+                .context("Failed to read tar header")?;
+            if block.iter().all(|&b| b == 0) {
+                bail!("No file found in tar archive");
+            }
+            let header = TarHeader::from_byte_slice(&block);
+            let size = header.size().context("Failed to read tar entry size")?;
+            if header.entry_type().is_file() && size > 0 {
+                return Ok(Self {
+                    inner,
+                    remaining: size,
+                });
+            }
+            io::copy(
+                &mut (&mut inner).take(tar_padded_size(size)),
+                &mut io::sink(),
+            )
+            .context("Failed to skip tar entry")?;
+        }
+    }
+}
+
+impl<R: Read> Read for TarFileReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if self.remaining == 0 {
+            return Ok(0);
+        }
+        let max = self.remaining.min(buf.len() as u64) as usize;
+        if max == 0 {
+            return Ok(0);
+        }
+        let n = self.inner.read(&mut buf[..max])?;
+        if n == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "Truncated tar entry",
+            ));
+        }
+        self.remaining -= n as u64;
+        Ok(n)
+    }
+}
+
+/// Async equivalent of [`TarFileReader`].
+struct AsyncTarFileReader<R> {
+    inner: R,
+    remaining: u64,
+}
+
+impl<R: AsyncRead + Unpin> AsyncTarFileReader<R> {
+    async fn new(mut inner: R) -> Result<Self> {
+        loop {
+            let mut block = [0u8; TAR_BLOCK_SIZE as usize];
+            inner
+                .read_exact(&mut block)
+                .await
+                .context("Failed to read tar header")?;
+            if block.iter().all(|&b| b == 0) {
+                bail!("No file found in tar archive");
+            }
+            let header = TarHeader::from_byte_slice(&block);
+            let size = header.size().context("Failed to read tar entry size")?;
+            if header.entry_type().is_file() && size > 0 {
+                return Ok(Self {
+                    inner,
+                    remaining: size,
+                });
+            }
+            futures::io::copy(
+                &mut (&mut inner).take(tar_padded_size(size)),
+                &mut futures::io::sink(),
+            )
+            .await
+            .context("Failed to skip tar entry")?;
+        }
+    }
+}
+
+impl<R: AsyncRead + Unpin> AsyncRead for AsyncTarFileReader<R> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        if self.remaining == 0 {
+            return Poll::Ready(Ok(0));
+        }
+        let max = self.remaining.min(buf.len() as u64) as usize;
+        if max == 0 {
+            return Poll::Ready(Ok(0));
+        }
+        match Pin::new(&mut self.inner).poll_read(cx, &mut buf[..max]) {
+            Poll::Ready(Ok(0)) => Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "Truncated tar entry",
+            ))),
+            Poll::Ready(Ok(n)) => {
+                self.remaining -= n as u64;
+                Poll::Ready(Ok(n))
+            }
+            other => other,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -178,11 +332,12 @@ impl SeekForward for Decoder {
 
 fn setup_local_input(path: &Path) -> Result<Decoder> {
     let f = File::open(path)?;
-    let compression = match classify_format(path) {
-        Some(compression) => compression,
+    let format = match classify_format(path) {
+        Some(format) => format,
         None => return Ok(Decoder::new(f)),
     };
-    let decompressed: Box<dyn Read> = match compression {
+    let decompressed: Box<dyn Read> = match format.compression {
+        Compression::None => Box::new(f),
         Compression::Gzip => Box::new(GzDecoder::new(f)),
         Compression::Bzip2 => Box::new(BzSyncDecoder::new(f)),
         Compression::Xz => Box::new(XzSyncDecoder::new(f)),
@@ -194,16 +349,23 @@ fn setup_local_input(path: &Path) -> Result<Decoder> {
         Compression::Lz4 => Box::new(Lz4SyncDecoder::new(f)),
         Compression::Zlib => Box::new(ZlibSyncDecoder::new(f)),
     };
-    Ok(Decoder::new(Discarder::new(decompressed)))
+    if format.tar {
+        Ok(Decoder::new(Discarder::new(TarFileReader::new(
+            decompressed,
+        )?)))
+    } else {
+        Ok(Decoder::new(Discarder::new(decompressed)))
+    }
 }
 
-fn wrap_async_decoder<S>(path: &Path, stream: S) -> Result<Box<dyn AsyncRead + Unpin + Send>>
+async fn wrap_async_decoder<S>(path: &Path, stream: S) -> Result<Box<dyn AsyncRead + Unpin + Send>>
 where
     S: futures::io::AsyncBufRead + Unpin + Send + 'static,
 {
-    let compression =
+    let format =
         classify_format(path).ok_or_else(|| anyhow!("Image file format not implemented"))?;
-    let decompressed: Box<dyn AsyncRead + Unpin + Send> = match compression {
+    let decompressed: Box<dyn AsyncRead + Unpin + Send> = match format.compression {
+        Compression::None => Box::new(stream),
         Compression::Gzip => Box::new(GzipDecoder::new(stream)),
         Compression::Bzip2 => Box::new(BzDecoder::new(stream)),
         Compression::Xz => Box::new(XzDecoder::new(stream)),
@@ -221,7 +383,11 @@ where
         Compression::Lz4 => Box::new(Lz4Decoder::new(stream)),
         Compression::Zlib => Box::new(ZlibDecoder::new(stream)),
     };
-    Ok(decompressed)
+    if format.tar {
+        Ok(Box::new(AsyncTarFileReader::new(decompressed).await?))
+    } else {
+        Ok(decompressed)
+    }
 }
 
 async fn setup_remote_input(url: Url) -> Result<Response> {
@@ -318,7 +484,7 @@ async fn copy_remote_input(source: Url, destination: PathBuf) -> Result<()> {
         .bytes_stream()
         .map_err(std::io::Error::other)
         .into_async_read();
-    let reader = wrap_async_decoder(&path, stream)?;
+    let reader = wrap_async_decoder(&path, stream).await?;
     let mut input = AsyncDiscarder::new(reader);
     let pb = setup_progress_bar(&bmap);
     bmap_parser::copy_async(
@@ -369,7 +535,7 @@ async fn copy_remote_input_nobmap(source: Url, destination: PathBuf) -> Result<(
         .bytes_stream()
         .map_err(std::io::Error::other)
         .into_async_read();
-    let reader = wrap_async_decoder(&path, stream)?;
+    let reader = wrap_async_decoder(&path, stream).await?;
     let mut input = AsyncDiscarder::new(reader);
     let pb = setup_spinner();
     bmap_parser::copy_async_nobmap(&mut input, &mut pb.wrap_async_write(&mut output).compat())
@@ -387,5 +553,159 @@ async fn main() -> Result<()> {
 
     match opts.command {
         Subcommand::Copy(c) => copy(c).await,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tar::{Builder, EntryType, Header};
+
+    /// Build an in-memory tar archive from `(name, data, entry_type)` entries.
+    fn tar_bytes(entries: &[(&str, &[u8], EntryType)]) -> Vec<u8> {
+        let mut builder = Builder::new(Vec::new());
+        for (name, data, entry_type) in entries {
+            let mut header = Header::new_gnu();
+            header.set_size(data.len() as u64);
+            header.set_entry_type(*entry_type);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder.append_data(&mut header, name, *data).unwrap();
+        }
+        builder.into_inner().unwrap()
+    }
+
+    #[test]
+    fn classify_plain_compression() {
+        for (name, compression) in [
+            ("disk.img.gz", Compression::Gzip),
+            ("disk.img.bz2", Compression::Bzip2),
+            ("disk.img.xz", Compression::Xz),
+            ("disk.img.zst", Compression::Zstd),
+            ("disk.img.lzma", Compression::Lzma),
+            ("disk.img.lz4", Compression::Lz4),
+            ("disk.img.zz", Compression::Zlib),
+        ] {
+            assert_eq!(
+                classify_format(Path::new(name)),
+                Some(Format {
+                    compression,
+                    tar: false
+                }),
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_tar_variants() {
+        for (name, compression) in [
+            ("disk.tar", Compression::None),
+            ("disk.tar.gz", Compression::Gzip),
+            ("disk.tgz", Compression::Gzip),
+            ("disk.tar.bz2", Compression::Bzip2),
+            ("disk.tbz2", Compression::Bzip2),
+            ("disk.tar.xz", Compression::Xz),
+            ("disk.tar.zst", Compression::Zstd),
+            ("disk.tar.lz4", Compression::Lz4),
+            ("disk.tar.lzma", Compression::Lzma),
+            ("disk.tar.zz", Compression::Zlib),
+        ] {
+            assert_eq!(
+                classify_format(Path::new(name)),
+                Some(Format {
+                    compression,
+                    tar: true
+                }),
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_tar_suffix_wins_over_bare() {
+        // ".tar.gz" also ends with ".gz"; the tar-aware suffix must win.
+        assert_eq!(
+            classify_format(Path::new("disk.tar.gz")),
+            Some(Format {
+                compression: Compression::Gzip,
+                tar: true
+            })
+        );
+    }
+
+    #[test]
+    fn classify_case_insensitive() {
+        assert_eq!(
+            classify_format(Path::new("DISK.TAR.GZ")),
+            Some(Format {
+                compression: Compression::Gzip,
+                tar: true
+            })
+        );
+    }
+
+    #[test]
+    fn classify_unknown_and_missing() {
+        assert_eq!(classify_format(Path::new("disk.img")), None);
+        assert_eq!(classify_format(Path::new("disk")), None);
+        assert_eq!(classify_format(Path::new("/")), None);
+    }
+
+    #[test]
+    fn tar_reader_extracts_single_file() {
+        let payload = b"the actual disk image contents";
+        let archive = tar_bytes(&[("disk.img", payload, EntryType::Regular)]);
+        let mut out = Vec::new();
+        TarFileReader::new(archive.as_slice())
+            .unwrap()
+            .read_to_end(&mut out)
+            .unwrap();
+        assert_eq!(out, payload);
+    }
+
+    #[test]
+    fn tar_reader_skips_leading_dir_and_empty_file() {
+        let payload = b"real image";
+        let archive = tar_bytes(&[
+            ("subdir/", b"", EntryType::Directory),
+            ("subdir/empty", b"", EntryType::Regular),
+            ("subdir/disk.img", payload, EntryType::Regular),
+        ]);
+        let mut out = Vec::new();
+        TarFileReader::new(archive.as_slice())
+            .unwrap()
+            .read_to_end(&mut out)
+            .unwrap();
+        assert_eq!(out, payload);
+    }
+
+    #[test]
+    fn tar_reader_errors_on_empty_archive() {
+        let archive = tar_bytes(&[]);
+        assert!(TarFileReader::new(archive.as_slice()).is_err());
+    }
+
+    #[test]
+    fn tar_reader_errors_on_truncated_entry() {
+        let payload = vec![0xabu8; 2000];
+        let archive = tar_bytes(&[("disk.img", &payload, EntryType::Regular)]);
+        // Keep the header block plus only part of the file data.
+        let truncated = &archive[..TAR_BLOCK_SIZE as usize + 500];
+        let mut reader = TarFileReader::new(truncated).unwrap();
+        let mut out = Vec::new();
+        assert!(reader.read_to_end(&mut out).is_err());
+    }
+
+    #[tokio::test]
+    async fn async_tar_reader_extracts_single_file() {
+        let payload = b"async disk image contents";
+        let archive = tar_bytes(&[("disk.img", payload, EntryType::Regular)]);
+        let mut reader = AsyncTarFileReader::new(futures::io::Cursor::new(archive))
+            .await
+            .unwrap();
+        let mut out = Vec::new();
+        reader.read_to_end(&mut out).await.unwrap();
+        assert_eq!(out, payload);
     }
 }


### PR DESCRIPTION
Use the right decompression format depending on the file extension.

Closes: https://github.com/collabora/bmap-rs/issues/32